### PR TITLE
added default return from .get to be empty string to fix unit test failure

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -91,7 +91,7 @@ class ContextRecall(MetricWithLLM):
         response = response if isinstance(response, list) else [response]
         response = [item if isinstance(item, dict) else {} for item in response]
         response = [
-            int(item.get("Attributed").strip() == "1")
+            int(item.get("Attributed", "").strip() == "1")
             if item.get("Attributed")
             else np.nan
             for item in response


### PR DESCRIPTION
I think your PR will correct problems I'm experiencing in RAGAS, but the unit test failed and prevented the merge. I think this fix will correct the issue.