### PR TITLE
added default return from .get to be empty string to fix unit test failure

### DIFF
--- a/src/ragas/metrics/_context_recall.py
+++ b/src/ragas/metrics/_context_recall.py
@@ -95,7 +95,7 @@ class ContextRecall(MetricWithLLM):
         data = [item if isinstance(item, dict) else {} for item in data]
         data = [
             (
-                int(item.get("attributed").strip() == "1")
+                int(item.get("attributed", "").strip() == "1")
                 if item.get("attributed")
                 else np.nan
             )


### PR DESCRIPTION
I believe your PR in the main RAGAS repo will fix issues I'm having but it was never merged due to a unit test error. I believe this change will resolve that bug.